### PR TITLE
Refined VarInt Parsing

### DIFF
--- a/analyzer/protobuf.spicy
+++ b/analyzer/protobuf.spicy
@@ -39,14 +39,14 @@ type TagAndValue = unit {
 #   0[0001]010 : varint payload, aka field number
 #   00001[010] : wire type (2, which is wire type LEN)
 type Tag = unit {
-    field_num: VarInt;
+    field_num: VarInt &convert=uint64($$.data);
     wire_type: uint64 &convert=WireType($$) if (False);
 
     on %done {
         # Last three bits are wire type
-        self.wire_type = WireType(self.field_num.data & 0x07);
+        self.wire_type = WireType(self.field_num & 0x07);
         # Upper bits are field number
-        self.field_num.data = self.field_num.data >> 3;
+        self.field_num = self.field_num >> 3;
     }
 };
 
@@ -58,7 +58,7 @@ type Tag = unit {
 #     A value is stored differently depending on the wire_type specified in the tag.
 type Value = unit(tag: Tag) {
     switch(tag.wire_type) {
-        WireType::VARINT -> varint  : VarInt;
+        WireType::VARINT -> varint  : VarInt &convert=uint64($$.data);
         WireType::I32    -> i32     : I32;
         WireType::I64    -> i64     : I64;
         # TODO - Finish switch for other types

--- a/analyzer/protobuf.spicy
+++ b/analyzer/protobuf.spicy
@@ -5,7 +5,7 @@ import spicy;
 # message := (tag value)*
 #     A message is encoded as a sequence of zero or more pairs of tags and values.
 public type Message = unit {
-    first_tag: TagAndValue;
+    first_field: TagAndValue;
     the_rest: bytes &eod;
     #message: TagAndValue[] &eod;
 

--- a/analyzer/protobuf.spicy
+++ b/analyzer/protobuf.spicy
@@ -5,9 +5,7 @@ import spicy;
 # message := (tag value)*
 #     A message is encoded as a sequence of zero or more pairs of tags and values.
 public type Message = unit {
-    first_field: TagAndValue;
-    the_rest: bytes &eod;
-    #message: TagAndValue[] &eod;
+    message: TagAndValue[] &eod;
 
     on %done {
         print self;
@@ -58,9 +56,12 @@ type Tag = unit {
 #     A value is stored differently depending on the wire_type specified in the tag.
 type Value = unit(tag: Tag) {
     switch(tag.wire_type) {
-        WireType::VARINT -> varint  : VarInt &convert=uint64($$.data);
-        WireType::I32    -> i32     : I32;
-        WireType::I64    -> i64     : I64;
+        WireType::VARINT -> varint : VarInt &convert=uint64($$.data);
+        WireType::I32    -> unimpl : bytes &eod;
+        WireType::I64    -> unimpl : bytes &eod;
+        WireType::LEN    -> unimpl : bytes &eod;
+        WireType::SGROUP -> unimpl : bytes &eod;
+        WireType::EGROUP -> unimpl : bytes &eod;
         # TODO - Finish switch for other types
     };
 };

--- a/analyzer/protobuf.spicy
+++ b/analyzer/protobuf.spicy
@@ -44,10 +44,7 @@ type Tag = unit {
         field_number: 1..4;
         wire_type: 5..7 &convert=WireType($$);
     } &bit-order=spicy::BitOrder::MSB0;
-    # TODO
-    on %done {
-        print "ignore: '%d' field_num: '%d' wire_type: '%d'" % (self.data.ignore, self.data.field_number, self.data.wire_type);
-    }
+    # TODO: treat tag as uint32 VarInt
 };
 
 # value := varint      for wire_type == VARINT,
@@ -58,20 +55,30 @@ type Tag = unit {
 #     A value is stored differently depending on the wire_type specified in the tag.
 type Value = unit(tag: Tag) {
     switch(tag.data.wire_type) {
-        WireType::VARINT -> var_int : VarInt;
+        WireType::VARINT -> varint : VarInt;
         WireType::I32    -> i32     : I32;
         WireType::I64    -> i64     : I64;
         # TODO - Finish switch for other types
     };
 };
 
+function parse_varint(buf: vector<uint8>) : uint64 {
+    local parsed: uint64 = 0;
+    local temp: uint64 = 0;
+    while (local i = 0; i < |buf|) {
+        # Drop continuation bit
+        temp = buf[i] & 0x7F; # Drop continuation bit
+        # Convert to big-endian
+        parsed = parsed | (temp << (i * 7));
+        ++i;
+    }
+    return parsed;
+}
+
 # varint := int32 | int64 | uint32 | uint64 | bool | enum | sint32 | sint64
 #     Encoded as varints (sintN are ZigZag-encoded first).
 type VarInt = unit {
-    data: uint8[] &until-including=($$ < 0x80);
-    on %done {
-        print "VarInt Data=%s" % self.data;
-    }
+    data: uint8[] &until-including=($$ < 0x80) &convert=parse_varint($$);
 };
 
 # i32 := sfixed32 | fixed32 | float

--- a/analyzer/protobuf.spicy
+++ b/analyzer/protobuf.spicy
@@ -45,6 +45,9 @@ type Tag = unit {
         wire_type: 5..7 &convert=WireType($$);
     } &bit-order=spicy::BitOrder::MSB0;
     # TODO
+    on %done {
+        print "ignore: '%d' field_num: '%d' wire_type: '%d'" % (self.data.ignore, self.data.field_number, self.data.wire_type);
+    }
 };
 
 # value := varint      for wire_type == VARINT,
@@ -65,16 +68,9 @@ type Value = unit(tag: Tag) {
 # varint := int32 | int64 | uint32 | uint64 | bool | enum | sint32 | sint64
 #     Encoded as varints (sintN are ZigZag-encoded first).
 type VarInt = unit {
-    data: VarIntOctet[] &until-including=(!($$.data.continuation_bit));
-};
-
-type VarIntOctet = unit {
-    data: bitfield(8) {
-        continuation_bit: 0;
-        payload: 1..7;
-    } &bit-order=spicy::BitOrder::MSB0;
+    data: uint8[] &until-including=($$ < 0x80);
     on %done {
-        print "Continuation Bit: %d; little-endian payload: %d" %(self.data.continuation_bit, self.data.payload);
+        print "VarInt Data=%s" % self.data;
     }
 };
 

--- a/analyzer/protobuf.spicy
+++ b/analyzer/protobuf.spicy
@@ -55,7 +55,7 @@ type Tag = unit {
 #     A value is stored differently depending on the wire_type specified in the tag.
 type Value = unit(tag: Tag) {
     switch(tag.data.wire_type) {
-        WireType::VARINT -> varint : VarInt;
+        WireType::VARINT -> varint  : VarInt;
         WireType::I32    -> i32     : I32;
         WireType::I64    -> i64     : I64;
         # TODO - Finish switch for other types

--- a/analyzer/protobuf.spicy
+++ b/analyzer/protobuf.spicy
@@ -39,12 +39,15 @@ type TagAndValue = unit {
 #   0[0001]010 : varint payload, aka field number
 #   00001[010] : wire type (2, which is wire type LEN)
 type Tag = unit {
-    data: bitfield(8) {
-        ignore: 0;
-        field_number: 1..4;
-        wire_type: 5..7 &convert=WireType($$);
-    } &bit-order=spicy::BitOrder::MSB0;
-    # TODO: treat tag as uint32 VarInt
+    field_num: VarInt;
+    wire_type: uint64 &convert=WireType($$) if (False);
+
+    on %done {
+        # Last three bits are wire type
+        self.wire_type = WireType(self.field_num.data & 0x07);
+        # Upper bits are field number
+        self.field_num.data = self.field_num.data >> 3;
+    }
 };
 
 # value := varint      for wire_type == VARINT,
@@ -54,7 +57,7 @@ type Tag = unit {
 #          <empty>     for wire_type == SGROUP or EGROUP
 #     A value is stored differently depending on the wire_type specified in the tag.
 type Value = unit(tag: Tag) {
-    switch(tag.data.wire_type) {
+    switch(tag.wire_type) {
         WireType::VARINT -> varint  : VarInt;
         WireType::I32    -> i32     : I32;
         WireType::I64    -> i64     : I64;

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -88,11 +88,13 @@ function build {
     done
 
     # TODO: Encapsulate tests within 'testing' directory
-    cmd="spicy-driver ./*.hlto -f ../test-data/protobuf_150.raw"
-    echo "============================================="
-    echo "Running ${cmd}"
-    echo "============================================="
-    eval "${cmd}"
+    for raw in ../test-data/*.raw; do
+      cmd="spicy-driver ./*.hlto -f ${raw}"
+      echo "============================================="
+      echo "Running ${cmd}"
+      echo "============================================="
+      eval "${cmd}"
+    done
     #pushd "../testing/" >/dev/null
     #make
     #popd >/dev/null

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -88,7 +88,7 @@ function build {
     done
 
     # TODO: Encapsulate tests within 'testing' directory
-    cmd="spicy-driver ./*.hlto -f ../test-data/protobuf_udp_addressbook.raw"
+    cmd="spicy-driver ./*.hlto -f ../test-data/protobuf_150.raw"
     echo "============================================="
     echo "Running ${cmd}"
     echo "============================================="
@@ -100,6 +100,7 @@ function build {
 }
 
 function main {
+  mkdir -p "${WD}"
   pushd "${WD}" >/dev/null
   process_args "${@}"
   build


### PR DESCRIPTION
There are a few changes in here, but the most interesting updates are to the `VarInt` unit. I took advantage of the `&convert=` attribute to translate variable-width integer input into a more usable `uint64`. I think we can avoid the whole custom C++ extension excursion this way, although that may be fun to revisit for performance purposes at some point. 🤔 

There's still plenty to do, but I think this is progress!

Change Log:
* Removed `VarIntOctet` unit in favor of `&until-including=($$ < 0x80)`
* Added a `parse_varint` function for use with `&convert` on `VarInt` units to translate variable width integers to their basic uint64 form.
* Treat `Tag` unit as a `VarInt`
* Cleaned up nested `data` fields where necessary by calling `&convert=uint64($$.data)`
* Moved handling of remaining data to `Value` unit switch statement

Example Run:
```
# ./tools/build.sh -t
...
=============================================
Running spicy-driver ./*.hlto -f ../test-data/protobuf_150.raw
=============================================
[$message=[[$tag=[$field_num=1, $wire_type=WireType::VARINT], $value=[$varint=150, $unimpl=(not set)]]]]
=============================================
Running spicy-driver ./*.hlto -f ../test-data/protobuf_udp_addressbook.raw
=============================================
[$message=[[$tag=[$field_num=1, $wire_type=WireType::LEN], $value=[$varint=(not set), $unimpl=b"B\x0a\x05Jason\x10\xe9\x07\x1a\x11Jason@example.com\"\x0c\x0a\x0887561234\x10\x01\"\x0d\x0a\x0b13588886666*\x06\x08\xa1\x8b\x97\xfc\x05\x0a:\x0a\x04Lily\x10\xea\x07\x1a\x10Lily@example.com\"\x0c\x0a\x0862858875\x10\x01\"\x0f\x0a\x0b18822228888\x10\x02"]]]]
```